### PR TITLE
fix(docker): clear all ten open Trivy findings against the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ than list every change.
 
 ## [Unreleased]
 
+### Security
+
+- **Cleared all ten open Trivy findings against the Docker image** (9 HIGH,
+  1 MEDIUM). Seven were util-linux/`libuuid` CVEs already fixed in
+  Alpine but not yet in the `python:3.14-alpine` tag; the runtime stage now
+  runs `apk upgrade` before installing its packages. The other three
+  (`msgpack` GHSA-6v7p-g79w-8964, `setuptools` CVE-2025-47273 and
+  CVE-2026-59890) were pip's *vendored* copies in `pip/_vendor/`, not anything
+  the application imports. The runtime image never installs packages — the venv
+  is built in the builder stage — so pip and the `ensurepip` wheel are now
+  removed from the final image. Trivy reports zero findings at any severity
+  afterwards; the CI smoke tests and the container healthcheck are unaffected.
+
 ### Removed
 
 - The Codecov upload step. It required a `CODECOV_TOKEN` that was never

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,21 @@ RUN uv venv && \
 # Runtime stage
 FROM python:3.14-alpine AS runtime
 
-# Install runtime system dependencies
-RUN apk add --no-cache \
+# Upgrade the base packages first: the python:*-alpine tag is rebuilt less
+# often than Alpine ships security fixes, so the image otherwise inherits
+# already-patched CVEs (e.g. util-linux/libuuid) that the Trivy scan flags.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
     whois \
     curl \
     ca-certificates
+
+# The runtime never installs anything: the venv is fully built in the builder
+# stage, so the interpreter's bundled pip is dead weight. It also vendors its
+# own copies of msgpack and setuptools (pip/_vendor/vendor.txt), which Trivy
+# scans and reports against, so remove pip and the ensurepip wheel outright.
+RUN /usr/local/bin/python -m pip uninstall --yes pip && \
+    rm -rf /usr/local/lib/python3.14/ensurepip/_bundled
 
 # Create non-root user for security
 RUN addgroup -g 1000 netflix && \


### PR DESCRIPTION
## Summary

Closes all 10 open code-scanning alerts (#29–#38), all raised by the Trivy image scan in `docker.yml`.

| Alerts | Package | Root cause | Fix |
| --- | --- | --- | --- |
| #32–#38 (7× HIGH) | `libuuid` 2.42.1-r0 | `python:3.14-alpine` tag lags Alpine's security updates | `apk upgrade` in the runtime stage → 2.42.3-r1 |
| #29 (HIGH) | `msgpack` 1.1.2 | pip's vendored copy (`pip/_vendor/vendor.txt`), not an app dependency | Remove pip + `ensurepip` wheel from the runtime image |
| #30, #31 (HIGH, MEDIUM) | `setuptools` 70.3.0 | same — vendored by pip | same |

The runtime image never installs packages (the venv is built in the builder stage), so dropping pip has no functional effect.

## Verification

- Built the image locally and scanned before/after with `aquasec/trivy:latest`: **11 → 0 findings** at all severities.
- CI smoke tests (`version`, `info`, `--help`) pass on the patched image.
- `HEALTHCHECK` command (`python -c "import netflix_oca_locator"`) still works.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)